### PR TITLE
Add media source JobTemplateAttribute

### DIFF
--- a/SharpIpp.Tests.Unit/Mapping/Profiles/JobTemplateAttributesProfileTests.cs
+++ b/SharpIpp.Tests.Unit/Mapping/Profiles/JobTemplateAttributesProfileTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SharpIpp.Mapping;
+using SharpIpp.Mapping.Extensions;
+using SharpIpp.Protocol;
+using SharpIpp.Protocol.Models;
+
+namespace SharpIpp.Tests.Unit.Mapping.Profiles;
+
+[TestClass]
+[ExcludeFromCodeCoverage]
+public class JobTemplateAttributesProfileTests
+{
+    private readonly IMapper _mapper;
+
+    public JobTemplateAttributesProfileTests()
+    {
+        var mapper = new SimpleMapper();
+        var assembly = Assembly.GetAssembly(typeof(SimpleMapper));
+        mapper.FillFromAssembly(assembly!);
+        _mapper = mapper;
+    }
+
+    [TestMethod]
+    public void Map_JobTemplateAttributes_WithMediaSource_ShouldMapToIppRequestMessage()
+    {
+        var src = new JobTemplateAttributes
+        {
+            MediaSource = MediaSource.Main
+        };
+
+        var result = _mapper.Map<IppRequestMessage>(src);
+        var mediaSourceAttr = result.JobAttributes.Single(a => a.Name == JobAttribute.MediaSource);
+
+        mediaSourceAttr.Tag.Should().Be(Tag.Keyword);
+        mediaSourceAttr.Value.Should().Be("main");
+    }
+
+    [TestMethod]
+    public void Map_IppRequestMessage_WithMediaSource_ShouldMapToJobTemplateAttributes()
+    {
+        var src = new Mock<IIppRequestMessage>();
+        src.SetupGet(x => x.JobAttributes).Returns(
+        [
+            new IppAttribute(Tag.Keyword, JobAttribute.MediaSource, "main")
+        ]);
+
+        var result = _mapper.Map<JobTemplateAttributes>(src.Object);
+
+        result.MediaSource.Should().Be(MediaSource.Main);
+    }
+}

--- a/SharpIpp/Mapping/Profiles/JobTemplateAttributesProfile.cs
+++ b/SharpIpp/Mapping/Profiles/JobTemplateAttributesProfile.cs
@@ -101,6 +101,9 @@ internal class JobTemplateAttributesProfile : IProfile
             if (src.MediaCol != null)
                 job.AddRange(map.Map<IEnumerable<IppAttribute>>(src.MediaCol).ToBegCollection(JobAttribute.MediaCol));
 
+            if (src.MediaSource != null)
+                job.Add(new IppAttribute(Tag.Keyword, JobAttribute.MediaSource, map.Map<string>(src.MediaSource.Value)));
+
             return dst;
         });
 
@@ -125,6 +128,8 @@ internal class JobTemplateAttributesProfile : IProfile
             dst.PrintColorMode = map.MapFromDicNullable<PrintColorMode?>(jobDict, JobAttribute.PrintColorMode);
             if (jobDict.ContainsKey(JobAttribute.MediaCol))
                 dst.MediaCol = map.Map<MediaCol>(jobDict[JobAttribute.MediaCol].FromBegCollection().ToIppDictionary());
+            if (jobDict.ContainsKey(JobAttribute.MediaSource))
+                dst.MediaSource = map.MapFromDicNullable<MediaSource?>(jobDict, JobAttribute.MediaSource);
             return dst;
         });
     }

--- a/SharpIpp/Protocol/Models/JobAttribute.cs
+++ b/SharpIpp/Protocol/Models/JobAttribute.cs
@@ -72,5 +72,6 @@ namespace SharpIpp.Protocol.Models
         public const string NumberOfDocuments = "number-of-documents";
         public const string OutputDeviceAssigned = "output-device-assigned";
         public const string MediaCol = "media-col";
+        public const string MediaSource = "media-source";
     }
 }

--- a/SharpIpp/Protocol/Models/JobTemplateAttributes.cs
+++ b/SharpIpp/Protocol/Models/JobTemplateAttributes.cs
@@ -185,5 +185,7 @@ namespace SharpIpp.Protocol.Models
 
         public MediaCol? MediaCol { get; set; }
 
+        public MediaSource? MediaSource { get; set; }
+
     }
 }


### PR DESCRIPTION
I want to add media-source to the jobAttributes. Without it I could not deliver the tray selection to my virtual printer in Windows. It did not work for me using MediaCol.

<img width="848" height="722" alt="image" src="https://github.com/user-attachments/assets/ee5df94d-cb09-4d95-9f72-cc756d928ec9" />

