### PR TITLE
Add "media-col-database" support

### DIFF
--- a/SharpIpp/Mapping/Profiles/MediaSizeProfile.cs
+++ b/SharpIpp/Mapping/Profiles/MediaSizeProfile.cs
@@ -11,11 +11,48 @@ internal class MediaSizeProfile : IProfile
     public void CreateMaps(IMapperConstructor mapper)
     {
         mapper.CreateMap<Dictionary<string, IppAttribute[]>, MediaSize>((src, map) =>
-            new MediaSize
+        {
+            int? xDimension = null;
+            int? yDimension = null;
+            Range? xDimensionRange = null;
+            Range? yDimensionRange = null;
+
+            try
             {
-                XDimension = map.MapFromDicNullable<int?>(src, nameof(MediaSize.XDimension).ConvertCamelCaseToKebabCase()),
-                YDimension = map.MapFromDicNullable<int?>(src, nameof(MediaSize.YDimension).ConvertCamelCaseToKebabCase())
-            });
+                xDimension =
+                    map.MapFromDicNullable<int?>(src, nameof(MediaSize.XDimension).ConvertCamelCaseToKebabCase());
+            }
+            catch (System.ArgumentException) { }
+            
+            try
+            {
+                yDimension =
+                    map.MapFromDicNullable<int?>(src, nameof(MediaSize.YDimension).ConvertCamelCaseToKebabCase());
+            }
+            catch (System.ArgumentException) { }
+            
+            try
+            {
+                xDimensionRange =
+                    map.MapFromDicNullable<Range?>(src, nameof(MediaSize.XDimension).ConvertCamelCaseToKebabCase());
+            }
+            catch (System.ArgumentException) { }
+            
+            try
+            {
+                yDimensionRange =
+                    map.MapFromDicNullable<Range?>(src, nameof(MediaSize.YDimension).ConvertCamelCaseToKebabCase());
+            }
+            catch (System.ArgumentException) { }
+            
+            return new MediaSize
+            {
+                XDimension = xDimension,
+                YDimension = yDimension,
+                XDimensionRange = xDimensionRange,
+                YDimensionRange = yDimensionRange
+            };
+        });
 
         mapper.CreateMap<MediaSize, IEnumerable<IppAttribute>>((src, map) =>
         {

--- a/SharpIpp/Mapping/Profiles/MediaSizeProfile.cs
+++ b/SharpIpp/Mapping/Profiles/MediaSizeProfile.cs
@@ -61,6 +61,11 @@ internal class MediaSizeProfile : IProfile
                 attributes.Add(new IppAttribute(Tag.Integer, nameof(MediaSize.XDimension).ConvertCamelCaseToKebabCase(), src.XDimension.Value));
             if (src.YDimension.HasValue)
                 attributes.Add(new IppAttribute(Tag.Integer, nameof(MediaSize.YDimension).ConvertCamelCaseToKebabCase(), src.YDimension.Value));
+            if (src.XDimensionRange.HasValue)
+                attributes.Add(new IppAttribute(Tag.RangeOfInteger, nameof(MediaSize.XDimension).ConvertCamelCaseToKebabCase(), src.XDimensionRange.Value));
+            if (src.YDimensionRange.HasValue)
+                attributes.Add(new IppAttribute(Tag.RangeOfInteger, nameof(MediaSize.YDimension).ConvertCamelCaseToKebabCase(), src.YDimensionRange.Value));
+
             return attributes;
         });
     }

--- a/SharpIpp/Mapping/Profiles/Responses/GetCUPSPrintersResponseProfile.cs
+++ b/SharpIpp/Mapping/Profiles/Responses/GetCUPSPrintersResponseProfile.cs
@@ -110,6 +110,7 @@ internal class GetCUPSPrintersResponseProfile : IProfile
                 JobHoldUntilSupported = map.MapFromDicSetNullable<JobHoldUntil[]?>(src, PrinterAttribute.JobHoldUntilSupported),
                 OutputBinDefault = map.MapFromDicNullable<string?>(src, PrinterAttribute.OutputBinDefault),
                 OutputBinSupported = map.MapFromDicSetNullable<string[]?>(src, PrinterAttribute.OutputBinSupported),
+                MediaColDatabase = src.ContainsKey(PrinterAttribute.MediaColDatabase) ? src[PrinterAttribute.MediaColDatabase].SplitBegCollection(PrinterAttribute.MediaColDatabase).Select(x => map.Map<MediaCol>(x.FromBegCollection().ToIppDictionary())).ToArray() : null,
                 MediaColDefault = src.ContainsKey(PrinterAttribute.MediaColDefault) ? map.Map<MediaCol>(src[PrinterAttribute.MediaColDefault].FromBegCollection().ToIppDictionary()) : null,
                 PrintColorModeDefault = map.MapFromDicNullable<PrintColorMode?>(src, PrinterAttribute.PrintColorModeDefault),
                 PrintColorModeSupported = map.MapFromDicSetNullable<PrintColorMode[]?>(src, PrinterAttribute.PrintColorModeSupported),
@@ -244,6 +245,8 @@ internal class GetCUPSPrintersResponseProfile : IProfile
                     dic.Add(PrinterAttribute.OutputBinDefault, new IppAttribute[] { new IppAttribute(Tag.Keyword, PrinterAttribute.OutputBinDefault, src.OutputBinDefault) });
                 if (src.OutputBinSupported != null)
                     dic.Add(PrinterAttribute.OutputBinSupported, src.OutputBinSupported.Select(x => new IppAttribute(Tag.Keyword, PrinterAttribute.OutputBinSupported, x)).ToArray());
+                if (src.MediaColDatabase != null)
+                    dic.Add(PrinterAttribute.MediaColDatabase, src.MediaColDatabase.Select(x => map.Map<IEnumerable<IppAttribute>>(x).ToBegCollection(PrinterAttribute.MediaColDatabase).ToArray()).SelectMany(array => array).ToArray());
                 if (src.MediaColDefault != null)
                     dic.Add(PrinterAttribute.MediaColDefault, map.Map<IEnumerable<IppAttribute>>(src.MediaColDefault).ToBegCollection(PrinterAttribute.MediaColDefault).ToArray());
                 if (src.PrintColorModeDefault != null)

--- a/SharpIpp/Protocol/Extensions/IppAttributeExtensions.cs
+++ b/SharpIpp/Protocol/Extensions/IppAttributeExtensions.cs
@@ -235,4 +235,37 @@ public static class IppAttributeExtensions
             }
         }
     }
+
+    /// <summary>
+    /// Splits a collection of <see cref="IppAttribute"/> to a smaller collections to be further processed by
+    /// <see cref="FromBegCollection"/> each.
+    /// </summary>
+    /// <param name="attributes">The collection of attributes starting with a collection tag.</param>
+    /// <param name="collectionName">The collection name</param>
+    /// <returns>An enumerable of list of attributes.</returns>
+    public static IEnumerable<IEnumerable<IppAttribute>> SplitBegCollection(this IEnumerable<IppAttribute> attributes,
+        string collectionName)
+    {
+        var isFirst = true;
+
+        var innerList = new List<IppAttribute>();
+        
+        foreach (var attribute in attributes)
+        {
+            if (attribute.Tag == Tag.BegCollection && attribute.Name == collectionName)
+            {
+                if (!isFirst)
+                {
+                    yield return innerList;
+                    innerList = new List<IppAttribute>();
+                }
+
+                isFirst = false;
+            }
+                
+            innerList.Add(new IppAttribute(attribute.Tag, attribute.Name, attribute.Value));
+        }
+
+        yield return innerList;
+    }
 }

--- a/SharpIpp/Protocol/Models/MediaSize.cs
+++ b/SharpIpp/Protocol/Models/MediaSize.cs
@@ -10,4 +10,14 @@ public class MediaSize
     /// integer(0:MAX))
     /// </summary>
     public int? YDimension { get; set; }
+    
+    /// <summary>
+    /// Range(0:MAX, 0:MAX))
+    /// </summary>
+    public Range? XDimensionRange { get; set; }
+
+    /// <summary>
+    /// Range(0:MAX, 0:MAX))
+    /// </summary>
+    public Range? YDimensionRange { get; set; }
 }

--- a/SharpIpp/Protocol/Models/PrinterAttribute.cs
+++ b/SharpIpp/Protocol/Models/PrinterAttribute.cs
@@ -67,6 +67,7 @@ namespace SharpIpp.Protocol.Models
         public const string JobHoldUntilSupported = "job-hold-until-supported";
         public const string OutputBinDefault = "output-bin-default";
         public const string OutputBinSupported = "output-bin-supported";
+        public const string MediaColDatabase = "media-col-database";
         public const string MediaColDefault = "media-col-default";
         public const string MediaColSupported = "media-col-supported";
         public const string MediaColReady = "media-col-ready";

--- a/SharpIpp/Protocol/Models/PrinterDescriptionAttributes.cs
+++ b/SharpIpp/Protocol/Models/PrinterDescriptionAttributes.cs
@@ -242,6 +242,7 @@ namespace SharpIpp.Protocol.Models
         public string? OutputBinDefault { get; set; }
 
         public string[]? OutputBinSupported { get; set; }
+        public MediaCol[]? MediaColDatabase { get; set; }
         public MediaCol? MediaColDefault { get; set; }
 
         public PrintColorMode? PrintColorModeDefault { get; set; }


### PR DESCRIPTION
This pull request adds **"media-col-database"** attribute (**6.9.36 media-col-database (1setOf collection) of the PWG 5100.7**) support to the library.

"media-col-database" is a required attribute of type 1SetOf collection. It contains collections of "media-col" collections of printer media database. Lists available media collections supported by the printer.

Size of the collection can be very large, so printer is not returning this collection by default. Get-Printer-Attributes operation with **"media-col-database"** value in the **"requested-attributes"** is required to obtain it.

"media-size" is the required member of the collection. It must contain either single integer size or range of dimensions. To support duality of "x-dimension" and "y-dimension" of "media-size" collection I've added XDimensionRange and YDimensionRange properties to the MediaSize class along with support of mapping it. 

Any sugestions to the pull request are welcome and appreciated. 
